### PR TITLE
fix(sync-charts): wrong index in chart name building

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -30,7 +30,7 @@ func Sync(binaryHelm string, configPath string, repoDest string, registryType st
 
 		for chart, versions := range charts.Charts {
 			for _, version := range versions {
-				chartName := repoName[0] + "/" + chart
+				chartName := repoName[index] + "/" + chart
 
 				pullAndPush(registry, chart, chartName, version)
 


### PR DESCRIPTION
When changing logic about protocol handling for registryUrl, forgot to test the impact on  the chart name.
This PR fixes this and allow to have a good name in Chart